### PR TITLE
Update rxjs to version 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@sentry/angular": "^6.18.2",
     "@sentry/tracing": "^6.18.2",
     "ngx-clipboard": "14.0.2",
-    "rxjs": "^6.6.3",
+    "rxjs": "^7.0.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"
   },


### PR DESCRIPTION
This pull request was created using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
The JSFIX run was completed by [wheeless](https://github.com/wheeless).
It bumps rxjs to version 7.0.0.

<details>
<summary>List of breaking changes where JSFIX found that there were no occurrences.</summary>

* toPromise: toPromise return type now returns T | undefined in TypeScript, which is correct, but may break builds.
* Subscription: add no longer returns an unnecessary Subscription reference. This was done to prevent confusion caused by a legacy behavior. You can now add and remove functions and Subscriptions as teardowns to and from a Subscription using add and remove directly. Before this, remove only accepted subscriptions.
* Subscriber: new Subscriber no longer takes 0-3 arguments. To create a Subscriber with 0-3 arguments, use Subscriber.create. However, please note that there is little to no reason that you should be creating Subscriber references directly, and Subscriber.create and new Subscriber are both deprecated.
* Leaked implementation detail _unsubscribeAndRecycle of Subscriber has been removed. Just use new Subscription objects
* ReplaySubject no longer schedules emissions when a scheduler is provided. If you need that behavior, please compose in observeOn using pipe, for example: new ReplaySubject(2, 3000).pipe(observeOn(asap))
* rxjs-compat: rxjs/Rx is no longer a valid import site.
* count: No longer passes source observable as a third argument to the predicate. That feature was rarely used, and of limited value. The workaround is to simply close over the source inside of the function if you need to access it in there.
* Calling .next on a Subject without passing a value is no longer allowed
* The static sortActions method on VirtualTimeScheduler is no longer publicly exposed by our TS types.
* Notification.createNext(undefined) will no longer return the exact same reference everytime.
* race: race() will no longer subscribe to subsequent observables if a provided source synchronously errors or completes. This means side effects that might have occurred during subscription in those rare cases will no longer occur.
* unsubscribe no longer available via the this context of observer functions. To reenable, set config.useDeprecatedNextContext = true on the rxjs config found at import { config } from 'rxjs';. Note that enabling this will result in a performance penalty for all consumer subscriptions.
* defer no longer allows factories to return void or undefined. All factories passed to defer must return a proper ObservableInput, such as Observable, Promise, et al. To get the same behavior as you may have relied on previously, return EMPTY or return of() from the factory.
* map: thisArg will now default to undefined. The previous default of MapSubscriber never made any sense. This will only affect code that calls map with a function and references this like so: source.pipe(map(function () { console.log(this); })). There wasn't anything useful about doing this, so the breakage is expected to be very minimal. If anything we're no longer leaking an implementation detail.
* mergeScan: mergeScan will no longer emit its inner state again upon completion.
* pairs: pairs will no longer function in IE without a polyfill for Object.entries. pairs itself is also deprecated in favor of users just using from(Object.entries(obj)).
* An undocumented behavior where passing a negative count argument to repeat would result in an observable that repeats forever.
* single operator will now throw for scenarios where values coming in are either not present, or do not match the provided predicate. Error types have thrown have also been updated, please check documentation for changes.
* skipLast: skipLast will no longer error when passed a negative number, rather it will simply return the source, as though 0 was passed.
* take and will now throw runtime error for arguments that are negative or NaN, this includes non-TS calls like take().
* takeLast now has runtime assertions that throw TypeErrors for invalid arguments. Calling takeLast without arguments or with an argument that is NaN will throw a TypeError
* zip: zip operators will no longer iterate provided iterables "as needed", instead the iterables will be treated as push-streams just like they would be everywhere else in RxJS. This means that passing an endless iterable will result in the thread locking up, as it will endlessly try to read from that iterable. This puts us in-line with all other Rx implementations. To work around this, it is probably best to use map or some combination of map and zip. For example, zip(source$, iterator) could be source$.pipe(map(value => [value, iterator.next().value])).
* zip: Zipping a single array will now have a different result. This is an extreme corner-case, because it is very unlikely that anyone would want to zip an array with nothing at all. The workaround would be to wrap the array in another array zip([[1,2,3]]). But again, that's pretty weird.
* ajax body serialization will now use default XHR behavior in all cases. If the body is a Blob, ArrayBuffer, any array buffer view (like a byte sequence, e.g. Uint8Array, etc), FormData, URLSearchParams, string, or ReadableStream, default handling is use. If the body is otherwise typeof "object", then it will be converted to JSON via JSON.stringify, and the Content-Type header will be set to application/json;charset=utf-8. All other types will emit an error.
* The Content-Type header passed to ajax configuration no longer has any effect on the serialization behavior of the AJAX request.
* ajax: In an extreme corner-case... If an error occurs, the responseType is "json", we're in IE, and the responseType is not valid JSON, the ajax observable will no longer emit a syntax error, rather it will emit a full AjaxError with more details.
* ajax: Ajax implementation drops support for IE10 and lower. This puts us in-line with other implementations and helps clean up code in this area
* some internal modules are no longer exported (not described in changelog)
</details>

<details>
<summary>List of breaking changes not automatically fixable by JSFIX (manual review before merge is recommended).</summary><blockquote>

<details open>
<summary>General breaking changes (not related to specific API usages in your code).</summary>

* onUnhandledError: Errors that occur during setup of an observable subscription, after the subscription has emitted an error, or completed will now throw in their own call stack. Before it would call console.warn. This is potentially breaking in edge cases for node applications, which may be configured to terminate for unhandled exceptions. In the unlikely event this affects you, you can configure the behavior to console.warn in the new configuration setting like so: import { config } from 'rxjs'; config.onUnhandledError = (err) => console.warn(err);
* TS: RxJS requires TS 4.2
* RxJS Error types Tests that are written with naive expectations against errors may fail now that errors have a proper stack property. In some testing frameworks, a deep equality check on two error instances will check the values in stack, which could be different.
</details>



<details open>
<summary>The following breaking changes are unlikely to affect your code. Below each bullet is listed the dependency usages detected by JSFIX that may be affected by the breaking change.</summary>

* Removed an undocumented behavior where passing a negative count argument to retry would result in an observable that repeats forever.
  - [src/app/services/redirect.service.ts#L24-L24](https://github.com/wheeless/HostMioFrontend/pull/3/commits/ff43993a77598f63fb4a2ec85819abc723a28e0b#diff-70f00932019db1192118211a278bba58d3c369d082f09cf939df273d216a0918L24-L24)<br><br>
* throwError: In an extreme corner case for usage, throwError is no longer able to emit a function as an error directly. If you need to push a function as an error, you will have to use the factory function to return the function like so: throwError(() => functionToEmit), in other words throwError(() => () => console.log('called later')).
  - [src/app/services/redirect.service.ts#L28-L28](https://github.com/wheeless/HostMioFrontend/pull/3/commits/ff43993a77598f63fb4a2ec85819abc723a28e0b#diff-70f00932019db1192118211a278bba58d3c369d082f09cf939df273d216a0918L28-L28)</details>

</details>

<details>
<summary>List of files JSFIX failed to analyze (<b>manual review before merge is recommended</b>).</summary>

* angular.json (TypeError) - emessage: Cannot read properties of undefined (reading 'sourceCode').

* package.json (TypeError) - emessage: Cannot read properties of undefined (reading 'sourceCode').

* src/app/components/display-task/display-task.component.ts (TypeError) - emessage: Cannot read properties of undefined (reading 'sourceCode').

* tsconfig.app.json (TypeError) - emessage: Cannot read properties of undefined (reading 'sourceCode').

* tsconfig.json (TypeError) - emessage: Cannot read properties of undefined (reading 'sourceCode').

* tsconfig.spec.json (TypeError) - emessage: Cannot read properties of undefined (reading 'sourceCode').

</details>

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.